### PR TITLE
Fix license in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -29,7 +29,7 @@ description:
        - Examples
 
 legal:
-  license: EUPL-1.2
+  license: CC0-1.0
 
 maintenance:
   type: "community"


### PR DESCRIPTION
The license file in the repository is a CC0 license, whilst the publiccode.yml mentioned it being EUPL.