### PR TITLE
Change CODEOWNERS to OSPO team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,53 +1,6 @@
-# Each line is a file pattern followed by one or more owners.
-
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @onursagir and @sgort will be requested for
+# the team @MinBZK/OSPO will be requested for
 # review when someone opens a pull request.
-* @sgort
 
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that only
-# modifies JS files, only @js-owner and not the global
-# owner(s) will be requested for a review.
-# *.js    @js-owner # Remove '#' where necessary to activate it
-
-# You can also use email addresses if you prefer. They'll be
-# used to look up users just like we do for commit author
-# emails.
-# *.go docs@example.com # Remove '#' where necessary to activate it
-
-# Teams can be specified as code owners as well. Teams should
-# be identified in the format @org/team-name. Teams must have
-# explicit write access to the repository. In this example,
-# the octocats team in the octo-org organization owns all .txt files.
-# *.txt @octo-org/octocats # Remove '#' where necessary to activate it
-
-# In this example, @doctocat owns any files in the build/logs
-# directory at the root of the repository and any of its
-# subdirectories.
-# /build/logs/ @doctocat # Remove '#' where necessary to activate it
-
-# The `docs/*` pattern will match files like
-# `docs/getting-started.md` but not further nested files like
-# `docs/build-app/troubleshooting.md`.
-# docs/*  docs@example.com # Remove '#' where necessary to activate it
-
-# In this example, @octocat owns any file in an apps directory
-# anywhere in your repository.
-# apps/ @octocat # Remove '#' where necessary to activate it
-
-# In this example, @doctocat owns any file in the `/apps/docs`
-# directory in the root of your repository and any of its
-# subdirectories.
-# /apps/docs/ @doctocat
-
-# In this example, any change inside the `/scripts` directory
-# will require approval from @doctocat or @octocat.
-# /scripts/ @doctocat @octocat # Remove '#' where necessary to activate it
-
-# In this example, @octocat owns any file in the `/apps`
-# directory in the root of your repository except for the `/apps/github`
-# subdirectory, as its owners are left empty.
-# /apps/ @octocat # Remove both '#' where necessary to activate it
-# /apps/github
+* @MinBZK/OSPO


### PR DESCRIPTION
Removing @sgort from his duty of checking all pull-requests. Thank you for your service.

Adding the OSPO team as a CODEOWNERS to enable ownership management through that team.